### PR TITLE
Make some config fields required

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -102,12 +102,16 @@ export const service: KapShareService = {
     accountName: {
       title: 'Storage Account Name',
       type: 'string',
+      minLength: 3,
+      maxLength: 24,
+      pattern: /^[a-z\d]+$/.source,
       default: '',
       required: true,
     },
     accountKey: {
       title: 'Storage Account Key',
       type: 'string',
+      minLength: 1,
       default: '',
       required: true,
     },

--- a/src/index.ts
+++ b/src/index.ts
@@ -103,16 +103,19 @@ export const service: KapShareService = {
       title: 'Storage Account Name',
       type: 'string',
       default: '',
+      required: true,
     },
     accountKey: {
       title: 'Storage Account Key',
       type: 'string',
       default: '',
+      required: true,
     },
     container: {
       title: 'Container',
       type: 'string',
       default: 'kap',
+      required: true,
     },
     filePattern: {
       title: 'File Name Pattern',
@@ -122,7 +125,7 @@ export const service: KapShareService = {
       default: '{kapName}',
     },
     urlPattern: {
-      title: 'URL Pattern.',
+      title: 'URL Pattern',
       description: `URL where uploaded files can be found. Defaults to ${defaultUrlPattern}.`,
       type: 'string',
       default: '',

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,7 @@ const action = async (context: KapContext<AzureConfig>) => {
       blobContentType: contentTypes.get(context.format),
     },
     onProgress: evt => {
-      context.setProgress('Uploading...', evt.loadedBytes / size);
+      context.setProgress('Uploading…', evt.loadedBytes / size);
     },
   });
 


### PR DESCRIPTION
I assume they are required? If so, marking them as required makes Kap show an icon to the user that they need to set the config.

Also, very cool that you're making this plugin. I'm one of the Kap authors. Let me know if you have any feedback/concerns about the plugin API.